### PR TITLE
Add Vim/Emacs links to README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -243,8 +243,8 @@ at PEGN.
 
 ## PEGN Related Tools and Resources
 
-* Vim Plugin
-* Emacs Plugin
+* [Vim Plugin](https://github.com/pegn/pegn-syntax)
+* [Emacs Plugin](https://github.com/pegn/pegn-mode)
 * VSCode Extension
 * Language Syntax Server
 * `pegn` Linter


### PR DESCRIPTION
Add links to existing tools as discussed in #9. Adding it again after #10 was closed after `master` -> `main` rename.